### PR TITLE
Fix No `render` method found error.

### DIFF
--- a/CombinedChart.android.js
+++ b/CombinedChart.android.js
@@ -77,6 +77,9 @@ class chart extends Component {
     constructor(props) {
         super(props);
     }
+    render(){
+        return null;
+    }
 }
 chart.propTypes = {
     chartType:PropTypes.string,


### PR DESCRIPTION
No `render` method found on the returned component instance: you may have forgotten to define `render`, returned null/false from a stateless component, or tried to render an element whose type is a function that isn't a React component.
