### PR TITLE
Add support for data value formatter using printf

### DIFF
--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
@@ -80,6 +80,19 @@ public class MPBarChartManager extends MPBarLineChartManager {
                 int[] colors=new int[]{Color.parseColor(config.getString("color"))};
                 dataSet.setColors(colors);
             }
+
+            if(config.hasKey("valueFormatter")){
+                ReadableMap formatterMap = config.getMap("valueFormatter");
+                if(formatterMap.hasKey("type")){
+                    String type = formatterMap.getString("type");
+                    if("printf".equalsIgnoreCase(type)){
+                        String format = "";
+                        if(formatterMap.hasKey("format")) format = formatterMap.getString("format");
+                        dataSet.setValueFormatter(new PrintfValueFormatter(format));
+                    }
+                }
+            }
+
             barData.addDataSet(dataSet);
 
         }

--- a/android/src/main/java/cn/mandata/react_native_mpchart/PrintfValueFormatter.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/PrintfValueFormatter.java
@@ -1,0 +1,21 @@
+package cn.mandata.react_native_mpchart;
+
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.formatter.ValueFormatter;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+import android.util.Log;
+
+public class PrintfValueFormatter implements ValueFormatter {
+
+  private String format = "";
+
+  public PrintfValueFormatter(String format){
+    if(format != null) this.format = format;
+  }
+
+  @Override
+  public String getFormattedValue(float value, Entry entry, int dataSetIndex, ViewPortHandler viewPortHandler) {
+    return String.format(format, value);
+  }
+}


### PR DESCRIPTION
For example, to format your values with 1 decimal place on a bar chart, add
 `valueFormatter: {
            type: "printf",
            format: "%.1f"
          }` to `yValues.config`
