### PR TITLE
Added support for valueTextSize for Bar Chart

### DIFF
--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
@@ -68,6 +68,11 @@ public class MPBarChartManager extends MPBarLineChartManager {
             BarDataSet dataSet=new BarDataSet(entries,label);
             ReadableMap config= map.getMap("config");
             if(config.hasKey("valueTextColor")) dataSet.setValueTextColor(Color.parseColor(config.getString("valueTextColor")));
+            
+            // Text Size for bar value
+
+            if(config.hasKey("valueTextSize")) dataSet.setValueTextSize((float)config.getDouble("valueTextSize"));
+
             if(config.hasKey("drawValues")) dataSet.setDrawValues(config.getBoolean("drawValues"));
             if(config.hasKey("colors")){
                 ReadableArray colorsArray = config.getArray("colors");

--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPLineChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPLineChartManager.java
@@ -83,6 +83,11 @@ public class MPLineChartManager extends MPBarLineChartManager {
             if(config.hasKey("lineWidth")) dataSet.setLineWidth((float) config.getDouble("lineWidth"));
             if(config.hasKey("drawValues")) dataSet.setDrawValues(config.getBoolean("drawValues"));
             if(config.hasKey("valueTextColor")) dataSet.setValueTextColor(Color.parseColor(config.getString("valueTextColor")));
+            
+            // Text Size for bar value
+
+            if(config.hasKey("valueTextSize")) dataSet.setValueTextSize((float)config.getDouble("valueTextSize"));
+
             if (config.hasKey("drawCircleHole")) dataSet.setDrawCircleHole(config.getBoolean("drawCircleHole"));
             if(config.hasKey("drawValues")) dataSet.setDrawValues(config.getBoolean("drawValues"));
             if(config.hasKey("drawStepped")) dataSet.setDrawStepped(config.getBoolean("drawStepped"));


### PR DESCRIPTION
valueTextSize for bar and line charts. To use, add valueTextSize to config:

`config:{
				        color:'#1874cd',
				        valueTextColor: '#1874cd',
				        valueTextSize: 14,
				      },`