### PR TITLE
Add mapping for valueTextColors

### DIFF
--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPBarChartManager.java
@@ -67,6 +67,15 @@ public class MPBarChartManager extends MPBarLineChartManager {
             entries.add(be);*/
             BarDataSet dataSet=new BarDataSet(entries,label);
             ReadableMap config= map.getMap("config");
+
+            if(config.hasKey("valueTextColors")){
+                ReadableArray colorsArray = config.getArray("valueTextColors");
+                ArrayList<Integer> colors = new ArrayList<>();
+                for(int c = 0; c < colorsArray.size(); c++){
+                    colors.add(Color.parseColor(colorsArray.getString(c)));
+                }
+                dataSet.setValueTextColors(colors);
+            }else
             if(config.hasKey("valueTextColor")) dataSet.setValueTextColor(Color.parseColor(config.getString("valueTextColor")));
             
             // Text Size for bar value

--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPLineChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPLineChartManager.java
@@ -81,6 +81,14 @@ public class MPLineChartManager extends MPBarLineChartManager {
             if(config.hasKey("drawCircles")) dataSet.setDrawCircles(config.getBoolean("drawCircles"));
             if(config.hasKey("circleSize")) dataSet.setCircleSize((float) config.getDouble("circleSize"));
             if(config.hasKey("lineWidth")) dataSet.setLineWidth((float) config.getDouble("lineWidth"));
+            if(config.hasKey("valueTextColors")){
+                ReadableArray colorsArray = config.getArray("valueTextColors");
+                ArrayList<Integer> colors = new ArrayList<>();
+                for(int c = 0; c < colorsArray.size(); c++){
+                    colors.add(Color.parseColor(colorsArray.getString(c)));
+                }
+                dataSet.setValueTextColors(colors);
+            }else
             if(config.hasKey("drawValues")) dataSet.setDrawValues(config.getBoolean("drawValues"));
             if(config.hasKey("valueTextColor")) dataSet.setValueTextColor(Color.parseColor(config.getString("valueTextColor")));
             

--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPPieChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPPieChartManager.java
@@ -126,6 +126,14 @@ public class MPPieChartManager extends MPPieRadarChartManager {
                 dataSet.setColors(colors);
             }
             if(config.hasKey("drawValues")) dataSet.setDrawValues(config.getBoolean("drawValues"));
+            if(config.hasKey("valueTextColors")){
+                ReadableArray colorsArray = config.getArray("valueTextColors");
+                ArrayList<Integer> colors = new ArrayList<>();
+                for(int c = 0; c < colorsArray.size(); c++){
+                    colors.add(Color.parseColor(colorsArray.getString(c)));
+                }
+                dataSet.setValueTextColors(colors);
+            }else
             if(config.hasKey("valueTextColor")) dataSet.setValueTextColor(Color.parseColor(config.getString("valueTextColor")));
             dataSet.setSliceSpace(3f);
             pieData.addDataSet(dataSet);


### PR DESCRIPTION
Allows setting the `valueTextColors` to be able to use multiple colors for the values.