### PR TITLE
Added option wordWrap to legend

### DIFF
--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPBarLineChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPBarLineChartManager.java
@@ -338,6 +338,7 @@ public class MPBarLineChartManager extends SimpleViewManager<BarLineChartBase> {
         if(v.hasKey("direction"))  legend.setDirection(Legend.LegendDirection.valueOf(v.getString("direction")));
 
         if(v.hasKey("legendForm"))  legend.setForm(Legend.LegendForm.valueOf(v.getString("legendForm")));
+        if(v.hasKey("wordWrap")) legend.setWordWrapEnabled(v.getBoolean("wordWrap"));
 
         if(v.hasKey("textColor"))  legend.setTextColor(Color.parseColor(v.getString("textColor")));
         if(v.hasKey("textSize"))  legend.setTextSize((float) v.getDouble("textSize"));

--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPPieRadarChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPPieRadarChartManager.java
@@ -92,6 +92,7 @@ public class MPPieRadarChartManager extends SimpleViewManager<PieRadarChartBase>
         if(v.hasKey("direction"))  legend.setDirection(Legend.LegendDirection.valueOf(v.getString("direction")));
 
         if(v.hasKey("legendForm"))  legend.setForm(Legend.LegendForm.valueOf(v.getString("legendForm")));
+        if(v.hasKey("wordWrap")) legend.setWordWrapEnabled(v.getBoolean("wordWrap"));
 
         if(v.hasKey("textColor"))  legend.setTextColor(Color.parseColor(v.getString("textColor")));
         if(v.hasKey("textSize"))  legend.setTextSize((float) v.getDouble("textSize"));


### PR DESCRIPTION
Chart legend can become too long and the rest is cut off at the moment.
So I added the option _wordWrap_ for legend. I checked and it works.

Usage: `<*Chart legend={{enabled:true, wordWrap:true}} .../>`

P.S.: I'm not sure if there's a need for recompilation or not.