### PR TITLE
fix/propgroup

### DIFF
--- a/android/src/main/java/cn/mandata/react_native_mpchart/MPCombinedChartManager.java
+++ b/android/src/main/java/cn/mandata/react_native_mpchart/MPCombinedChartManager.java
@@ -7,7 +7,7 @@ import android.graphics.Paint;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.ReactPropGroup;
+import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;


### PR DESCRIPTION
the class MPCombinedChartManager was still importing the old ReactPropGroup class
See https://github.com/facebook/react-native/commit/c1b7a369af7ca457819d682b15f47fae7e2732fc for more